### PR TITLE
Fixed bad requests (url="http:/")

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Its Python logic mostly uses standard built-in modules but also some particular 
 ## Installation
 
  ```session
- $ sudo pip install webgrep-tool
+ $ pip install webgrep-tool
  ```
 
  > **Behind a proxy ?**

--- a/webgrep
+++ b/webgrep
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
+import code
 
 __author__ = "Alexandre D'Hondt"
 __email__ = "alexandre.dhondt@gmail.com"
@@ -255,7 +256,7 @@ def __installed(item, itype, message=None):
             return True
         except OSError:
             if message is not None:
-                logger.warn(message)
+                logger.warning(message)
             return False
     elif itype == 'module':
         try:
@@ -263,13 +264,13 @@ def __installed(item, itype, message=None):
             return True
         except ImportError:
             if message is not None:
-                logger.warn(message)
+                logger.warning(message)
             return False
     elif itype == 'function':
         # no check required ; this relates to a locally declared function
         return True
     else:
-        logger.warn("Unknown item type ({})".format(itype))
+        logger.warning("Unknown item type ({})".format(itype))
 
 
 # --------------------- CLASSES SECTION ---------------------
@@ -341,6 +342,7 @@ class Resource(object):
                'Upgrade-Insecure-Requests': "1"}
 
     def __init__(self, url, parent=None):
+        if not re.match('https?:\/\/(www\.)?.+', url): raise Exception('Invalid URL')
         self.url = url
         self.parent = parent
         self.path = dirname(url) + "/"
@@ -373,7 +375,7 @@ class Resource(object):
                 if enc.strip() not in ["none", "base64"]:
                     raise Exception("Bad image encoding")
             except Exception as e:
-                logger.warn("{} (from {})".format(str(e), self.parent.rel_fn))
+                logger.warning("{} (from {})".format(str(e), self.parent.rel_fn))
                 self._error = True
                 return
             fn = DATA_NAME.format(self.type, self.parent._raw_data, ext)
@@ -423,6 +425,7 @@ class Resource(object):
         Resource loading for use with '--keep-files', allowing to re-grep on
          different keywords without re-downloading everything.
         """
+
         if exists(self.abs_fn) and args.cache is not None and \
             self.rel_fn in args.cache.keys():
             with open(self.abs_fn, 'rb') as f:
@@ -589,18 +592,24 @@ class Resource(object):
             # download images
             for img in self.soup.find_all("img", src=True):
                 url = urljoin(self.path, img['src'])
-                with Resource(url, self) as res:
-                    res.grep().handle()
+                try:
+                    with Resource(url, self) as res:
+                        res.grep().handle()
+                except Exception: pass
             # download scripts
             for script in self.soup.find_all("script", src=True):
                 url = urljoin(self.path, script.attrs['src'])
-                with Resource(url, self) as res:
-                    res.grep().handle()
+                try:
+                    with Resource(url, self) as res:
+                        res.grep().handle()
+                except Exception: pass 
             # download styles
             for link in self.soup.find_all("link", href=True, rel="stylesheet"):
                 url = urljoin(self.path, link.attrs['href'])
-                with Resource(url, self) as res:
-                    res.grep().handle()
+                try:
+                    with Resource(url, self) as res:
+                        res.grep().handle()
+                except Exception: pass
         elif self.type == "style":
             # search for image URLs in the style sheet
             for url in CSS_URL_REGEX.findall(self.content):
@@ -608,8 +617,10 @@ class Resource(object):
                 if url.startswith("#"):  # exclude anchor tags
                     continue
                 url = urljoin(self.path, url)
-                with Resource(url, self) as res:
-                    res.grep().handle()
+                try:
+                    with Resource(url, self) as res:
+                        res.grep().handle()
+                except Exception: pass
 
     def preprocess(self):
         """
@@ -851,8 +862,11 @@ if __name__ == '__main__':
                 continue
             logger.debug("Downloading page {} and its associated resources"
                          .format(url))
-            with Resource(url) as page:
-                page.grep().handle()
+            try:
+                with Resource(url) as page:
+                    page.grep().handle()
+            except Exception as e:
+                logger.exception(e)
             done.append(url)
     except Exception as e:
         logger.exception("Unexpected error: {}".format(str(e)))

--- a/webgrep
+++ b/webgrep
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-import code
 
 __author__ = "Alexandre D'Hondt"
 __email__ = "alexandre.dhondt@gmail.com"

--- a/webgrep
+++ b/webgrep
@@ -45,20 +45,6 @@ if P3:
 else:
     from urllib import getproxies, unquote
     from urlparse import urljoin, urlparse
-# BeautifulSoup
-try:
-    import bs4
-except ImportError:
-    print("BeautifulSoup is not installed !\nPlease run 'sudo pip install"
-          " beautifulsoup4' before continuing.")
-    sys.exit(1)
-# colorize logging
-try:
-    import coloredlogs
-    colored_logs_present = True
-except ImportError:
-    print("(Install 'coloredlogs' for colored logging)")
-    colored_logs_present = False
 # disable annoying requests warnings
 try:
     from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -184,20 +170,6 @@ def tesseract(res):
 
 
 RESOURCE_TYPES = ['page', 'image', 'script', 'style']
-IMAGE_TOOLS = {
-    "exiftool": ('binary', get_cmd("exiftool"),
-                 "Binary required for getting image EXIF info ;\n"
-                 " consider running 'sudo apt-get install exiftool'"),
-    "strings": ('binary', get_cmd("strings"),
-                "Binary required for getting strings from downloaded files ;"
-                "\n consider running 'sudo apt-get install strings'"),
-    "steghide": ('binary', steghide,
-                 "Binary required for applying steganography on images ;"
-                 "\n consider running 'sudo apt-get install steghide'"),
-    "tesseract": ('binary', tesseract,
-                  "Binary required for trying OCR on images ;"
-                  "\n consider running 'sudo apt-get install tesseract-ocr'"),
-}
 PAGE_PREPROCESSORS = {
     "inline-script": ('function', inline_items("script", attrs={'src': False}),
                       None),
@@ -207,7 +179,7 @@ SCRIPT_PREPROCESSORS = {
     "jsbeautifier": ('module',
                      lambda r: b(jsbeautifier.beautify(s(r.content))),
                      "Python library required for deobfuscating Javascript ;"
-                     "\n consider running 'sudo pip install jsbeautifier'"),
+                     "\n consider running 'pip install jsbeautifier'"),
 }
 STYLE_PREPROCESSORS = {
     "unminifier": ('function', css_unminifier, None),
@@ -519,7 +491,8 @@ class Resource(object):
             pass
         else:
             reason = "({} - {})".format(resp.status_code, resp.reason)
-            logger.error("Failed to get {} {}".format(self.url, reason))
+            if args.verbose >= logging.ERROR: 
+                logger.error("Failed to get {} {}".format(self.url, reason))
         return self
 
     def grep(self):
@@ -809,6 +782,37 @@ if __name__ == '__main__':
                      help="manually set the HTTPS proxy")
     # ----- END new arguments -----
     args = parser.parse_args()
+    if args.verbose:
+        IMAGE_TOOLS = {
+            "exiftool": ('binary', get_cmd("exiftool"),
+                         "Binary required for getting image EXIF info ;\n"
+                         " consider running 'sudo apt-get install exiftool'"),
+            "strings": ('binary', get_cmd("strings"),
+                        "Binary required for getting strings from downloaded files ;"
+                        "\n consider running 'sudo apt-get install strings'"),
+            "steghide": ('binary', steghide,
+                         "Binary required for applying steganography on images ;"
+                         "\n consider running 'sudo apt-get install steghide'"),
+            "tesseract": ('binary', tesseract,
+                          "Binary required for trying OCR on images ;"
+                          "\n consider running 'sudo apt-get install tesseract-ocr'"),
+        }
+    # BeautifulSoup
+    try:
+        import bs4
+    except ImportError:
+        if args.verbose:
+            print("BeautifulSoup is not installed !\nPlease run 'pip install"
+              " beautifulsoup4' before continuing.")
+        sys.exit(1)
+    # colorize logging
+    try:
+        import coloredlogs
+        colored_logs_present = True
+    except ImportError:
+        if args.verbose:
+            print("(Install 'coloredlogs' for colored logging)")
+        colored_logs_present = False
     args.cache = None
     if not args.keep:
         try:


### PR DESCRIPTION
Hi there
Great tool you have made
I made some changes that better suited my use case (I gotta pipe the output so it has to be really clean on the least verbose level)
I also fixed (?) a strange error of a malformed request that was being created through a `Resource` object with a bad url.

- replaced `logger.warn` for `logger.warning`
- removed every unnecessary `sudo pip` instruction
- optional dependencies logging is now dependant on verbose level
- error logging in download function now depends on verbose level

?*: there's probably a better way to do this; the url regex is too simplified and may give some false positives.